### PR TITLE
fix: check that frozen.build exists before trying to access it

### DIFF
--- a/lib/TransformNormalModulePlugin.js
+++ b/lib/TransformNormalModulePlugin.js
@@ -598,7 +598,7 @@ class TransformNormalModulePlugin {
           module.request &&
           (cacheable(module) || !module.built) &&
           module instanceof NormalModule &&
-          (!frozen ||
+          (!frozen || !frozen.build ||
             (schema >= 4 && module.hash !== frozen.build.hash) ||
             (schema < 4 &&
               module.getHashDigest(extra.compilation.dependencyTemplates) !==


### PR DESCRIPTION
If there is a compilation where frozen.build is not generated for some reason, then the check here would fail and throw an exception:

   Could not freeze FILE_NAME: Cannot read property 'hash' of undefined

We check to see if the build exists and then fall through to regenerate if it does not.