### PR TITLE
fix: return value from updateMd5CacheItem

### DIFF
--- a/lib/CacheMd5.js
+++ b/lib/CacheMd5.js
@@ -382,6 +382,11 @@ class Md5Cache {
                 md5Cache[file] = value;
                 cachedMd5s[file] = value.hash;
               }
+
+              // If somehow dependencies operates on a file in both file and
+              // context, or otherwise doubles up, return value so the second
+              // call receives input.
+              return value;
             }
 
             const building = buildingMd5s[file];


### PR DESCRIPTION
Return a value so that a second call to updateMd5CacheItem on the stored promise is given the input the first call received to keep from throwing an error.